### PR TITLE
Remove android.r8.optimizedResourceShrinking

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ android.enablePartialRIncrementalBuilds=true
 android.enableResourceOptimizations=true
 android.generateManifestClass=true
 android.keepWorkerActionServicesBetweenBuilds=true
-android.r8.optimizedResourceShrinking=true
 android.r8.strictFullModeForKeepRules=true
 android.useAndroidX=true
 
@@ -27,8 +26,5 @@ android.suppressUnsupportedOptionWarnings=android.disableEarlyManifestParsing,\
   android.enableNewResourceShrinker.preciseShrinking,\
   android.enableParallelJsonGen,\
   android.enablePartialRIncrementalBuilds,\
-  android.experimental.gradual.r8,\
   android.keepWorkerActionServicesBetweenBuilds,\
-  android.r8.gradual.support,\
-  android.r8.optimizedResourceShrinking,\
   android.suppressUnsupportedOptionWarnings


### PR DESCRIPTION
It breaks signed TV builds for some reason (but not mobile, though).